### PR TITLE
Feat/see all customer subscriptions

### DIFF
--- a/app/controllers/api/v1/customer_subscriptions_controller.rb
+++ b/app/controllers/api/v1/customer_subscriptions_controller.rb
@@ -2,7 +2,13 @@ class Api::V1::CustomerSubscriptionsController < ApplicationController
   def index
     customer = Customer.find(params[:id])
 
-    render json: CustomerSubscriptionSerializer.new(customer.customer_subscriptions), status: 200
+    if params[:status] == 'active'
+      render json: CustomerSubscriptionSerializer.new(customer.customer_subscriptions.active), status: 200
+    elsif params[:status] == 'cancelled'
+      render json: CustomerSubscriptionSerializer.new(customer.customer_subscriptions.cancelled), status: 200
+    else
+      render json: CustomerSubscriptionSerializer.new(customer.customer_subscriptions), status: 200
+    end
   end
 
   def create

--- a/app/controllers/api/v1/customer_subscriptions_controller.rb
+++ b/app/controllers/api/v1/customer_subscriptions_controller.rb
@@ -1,4 +1,10 @@
 class Api::V1::CustomerSubscriptionsController < ApplicationController
+  def index
+    customer = Customer.find(params[:id])
+
+    render json: CustomerSubscriptionSerializer.new(customer.customer_subscriptions), status: 200
+  end
+
   def create
     customer_subscription = CustomerSubscription.new(cs_params)
     customer_subscription.save!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :customer_subscriptions, only: [:index, :create, :update]
+      get '/customer_subscriptions/:id', to: 'customer_subscriptions#index'
     end
   end
 end

--- a/spec/requests/api/v1/customer_subscriptions_spec.rb
+++ b/spec/requests/api/v1/customer_subscriptions_spec.rb
@@ -85,5 +85,57 @@ RSpec.describe "CustomerSubscriptions", type: :request do
         expect(subscription[:relationships]).to have_key(:subscription)
       end
     end
+
+    it 'returns all ACTIVE customer_subscriptions for the customer_id passed in the uri if a query param of status=active is passed' do
+      cs1 = CustomerSubscription.create!(customer_id: @customer1.id, subscription_id: @subscription1.id)
+      cs2 = CustomerSubscription.create!(customer_id: @customer1.id, subscription_id: @subscription3.id, status: 'cancelled')
+      cs3 = CustomerSubscription.create!(customer_id: @customer1.id, subscription_id: @subscription4.id)
+
+      get "/api/v1/customer_subscriptions/#{@customer1.id}?status=active"
+
+      customer_subscriptions = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(response).to be_successful
+      expect(response.status).to eq 200
+
+      expect(customer_subscriptions.count).to eq(2)
+      expect(customer_subscriptions.first[:id]).to eq(cs1.id.to_s)
+      expect(customer_subscriptions.first[:relationships][:subscription][:data][:id]).to eq(@subscription1.id.to_s)
+      expect(customer_subscriptions.last[:id]).to eq(cs3.id.to_s)
+      expect(customer_subscriptions.last[:relationships][:subscription][:data][:id]).to eq(@subscription4.id.to_s)
+
+      customer_subscriptions.each do |subscription|
+        expect(subscription[:type]).to eq('customer_subscription')
+        expect(subscription[:attributes][:status]).to eq('active')
+        expect(subscription[:relationships]).to have_key(:customer)
+        expect(subscription[:relationships][:customer][:data][:id]).to eq(@customer1.id.to_s)
+        expect(subscription[:relationships]).to have_key(:subscription)
+      end
+    end
+
+    it 'returns all CANCELLED customer_subscriptions for the customer_id passed in the uri if a query param of status=cancelled is passed' do
+      cs1 = CustomerSubscription.create!(customer_id: @customer1.id, subscription_id: @subscription1.id)
+      cs2 = CustomerSubscription.create!(customer_id: @customer1.id, subscription_id: @subscription3.id, status: 'cancelled')
+      cs3 = CustomerSubscription.create!(customer_id: @customer1.id, subscription_id: @subscription4.id)
+
+      get "/api/v1/customer_subscriptions/#{@customer1.id}?status=cancelled"
+
+      customer_subscriptions = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(response).to be_successful
+      expect(response.status).to eq 200
+
+      expect(customer_subscriptions.count).to eq(1)
+      expect(customer_subscriptions.first[:id]).to eq(cs2.id.to_s)
+      expect(customer_subscriptions.first[:relationships][:subscription][:data][:id]).to eq(@subscription3.id.to_s)
+
+      customer_subscriptions.each do |subscription|
+        expect(subscription[:type]).to eq('customer_subscription')
+        expect(subscription[:attributes][:status]).to eq('cancelled')
+        expect(subscription[:relationships]).to have_key(:customer)
+        expect(subscription[:relationships][:customer][:data][:id]).to eq(@customer1.id.to_s)
+        expect(subscription[:relationships]).to have_key(:subscription)
+      end
+    end
   end
 end


### PR DESCRIPTION
- Add endpoint for getting all customer subscriptions for a customer
- Add functionality to accept query params to filter active and cancelled customer subscriptions
- Update route to accept the customer ID in the URI rather than the body

Close #4 